### PR TITLE
feat(devcontainer): add the ability to use GitHub Codespaces and VS Code remote containers

### DIFF
--- a/.devcontainer/.dockerignore
+++ b/.devcontainer/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
+ARG VARIANT=16-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node modules
+# RUN su node -c "npm install -g <your-package-list-here>"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+	"name": "inspirational-quotes",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "quotes",
+	"workspaceFolder": "/workspace",
+	"settings": {},
+	"extensions": [
+		"dbaeumer.vscode-eslint",
+		"EditorConfig.EditorConfig",
+		"esbenp.prettier-vscode",
+		"ZixuanChen.vitest-explorer"
+	],
+	"postCreateCommand": "sudo chown -R node:node node_modules && yarn install --non-interactive",
+	"remoteUser": "node"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,10 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "quotes",
 	"workspaceFolder": "/workspace",
-	"settings": {},
+	"settings": {
+		"editor.formatOnSave": true,
+		"testing.automaticallyOpenPeekView": "never"
+	},
 	"extensions": [
 		"dbaeumer.vscode-eslint",
 		"EditorConfig.EditorConfig",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+
+services:
+  quotes:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        VARIANT: 16-bullseye
+
+    volumes:
+      - ..:/workspace:cached
+      - quotes_node_modules:/workspace/node_modules
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: /bin/sh -c "while sleep 1000; do :; done"
+
+volumes:
+  quotes_node_modules:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@ Hi! We're really excited that you're interested in contributing to this package!
 
 The `inspirational-quotes` packages' dependencies are installed using [Yarn](https://yarnpkg.com/).
 
-To develop and test the `inspirational-quotes` package:
+> _Note_ that this repository is compatible with GitHub Codespaces as well as VS Code Remote Containers. Opening your cloned project with either of these options will perform these dev setup steps for you automatically!
 
-> *Note* that this repository is compatible with GitHub Codespaces as well as VS Code Remote Containers. Opening your cloned project with either of these options will perform these dev setup steps for you automatically!
+To develop and test the `inspirational-quotes` package:
 
 1. Clone the repo
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ The `inspirational-quotes` packages' dependencies are installed using [Yarn](htt
 
 To develop and test the `inspirational-quotes` package:
 
+> *Note* that this repository is compatible with GitHub Codespaces as well as VS Code Remote Containers. Opening your cloned project with either of these options will perform these dev setup steps for you automatically!
+
 1. Clone the repo
 
 ```shell


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This project is marked as open to contribution for `Hacktoberfest`, and as such I figured it would be desirable for contributors to have a simplified means of getting up and running with the developer setup. With the addition of the `devcontainer` configuration, this project is now compatible with `GitHub Codespaces` as well as `VS Code Remote Containers`. Contributors who use one of these options now get all of the dev setup steps completed for them, and you get peace of mind that contributions will come from setups with the correct usage of eslint, prettier, vitest, etc.

### Additional context

**Demo using GH Codespaces**

[Demo](https://user-images.githubusercontent.com/34140052/194139365-c5b3249a-1c66-4b06-b4a4-b4e88697b940.mp4)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Add quotes
- [ ] Bug fix
- [x] New Feature
- [ ] Add more tests
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123` or `closes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
