### PR TITLE
:white_check_mark: Add test to check for duplicate quotes

### DIFF
--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -26,6 +26,13 @@ describe(`All Quotes`, () => {
 			assert(!quote.quote.includes(`'`))
 		}
 	})
+
+	test(`Test 04 : Check for duplicate quotes`, () => {
+		const allQuotes = getAll()
+		const allQuoteStrings = allQuotes.map((quoteObj) => quoteObj.quote)
+		const uniqueQuoteStrings = [...new Set(allQuoteStrings)]
+		expect(allQuoteStrings).toEqual(uniqueQuoteStrings)
+	})
 })
 
 describe(`Random Quote`, () => {

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -1,10 +1,15 @@
-import { assert, describe, expect, test } from 'vitest'
+import { assert, beforeEach, describe, expect, test } from 'vitest'
 import { getAll, getRandom } from '../src/index'
 import { quotes } from '../src/quotes'
+import { Quote } from '../src/types'
 
 describe(`All Quotes`, () => {
+	let allQuotes: Quote[]
+	beforeEach(() => {
+		allQuotes = getAll()
+	})
+
 	test(`Test 01: Get all Quotes`, () => {
-		const allQuotes = getAll()
 		expect(allQuotes).toEqual(quotes)
 		assert(allQuotes.length > 0)
 		for (const quote of allQuotes) {
@@ -14,21 +19,18 @@ describe(`All Quotes`, () => {
 	})
 
 	test(`Test 02: All Quotes end with a period`, () => {
-		const allQuotes = getAll()
 		for (const quote of allQuotes) {
 			assert(quote.quote.endsWith(`.`) || quote.quote.endsWith(`!`))
 		}
 	})
 
 	test(`Test 03 : Check for proper quote format`, () => {
-		const allQuotes = getAll()
 		for (const quote of allQuotes) {
 			assert(!quote.quote.includes(`'`))
 		}
 	})
 
 	test(`Test 04 : Check for duplicate quotes`, () => {
-		const allQuotes = getAll()
 		const allQuoteStrings = allQuotes.map((quoteObj) => quoteObj.quote)
 		const uniqueQuoteStrings = [...new Set(allQuoteStrings)]
 		expect(allQuoteStrings).toEqual(uniqueQuoteStrings)


### PR DESCRIPTION
### Description

This PR adds a test to checks for duplicate quotes. Closes #6 

### Additional context

I've noticed a repeated line of code in `All Quotes` tests. Which is
```js
test(`Test 01: Get all Quotes`, () => {
  const allQuotes = getAll() // repeated code
  // some tests/assertions
})

```

I think we can reduce this by appending beforeEach at the top. What do you think?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Add quotes
- [ ] Bug fix
- [ ] New Feature
- [x] Add more tests
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123` or `closes #123`).
- [z] Ideally, include relevant tests that fail without this PR but pass with it.
